### PR TITLE
bugfix in tile_osm_file

### DIFF
--- a/src/tile.jl
+++ b/src/tile.jl
@@ -278,6 +278,9 @@ function tile_osm_file(filename::AbstractString, bounds::Bounds = getbounds(file
 
     while !eof(io)
         line = readline(io)
+        if isempty(line)
+            continue
+        end
         type, subtype, id = gettag(line)
         if type == :node
             curtileset = gettiles(nodesDict[id],boundstiles,nodesnn)


### PR DESCRIPTION
Added workoround in tile_osm_file() for .osm files with empty lines.